### PR TITLE
Add live cell tracking chart

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -186,4 +186,16 @@ h1 {
 @keyframes pulse {
     0%, 100% { opacity: 1; transform: scale(1); }
     50% { opacity: 0.5; transform: scale(1.1); }
-} 
+}
+
+.chart-container {
+    width: 80%;
+    max-width: 800px;
+    margin-top: 20px;
+}
+
+#liveChart {
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 15px;
+    padding: 10px;
+}

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Conway's Game of Life - Ultra Fast Enhanced</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.2/p5.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
@@ -79,9 +80,14 @@
         </div>
     </div>
 
+    <div class="chart-container">
+        <canvas id="liveChart"></canvas>
+    </div>
+
     <!-- Scripts in correct order -->
     <script src="js/utils.js"></script>
     <script src="js/game.js"></script>
     <script src="js/ui.js"></script>
+    <script src="js/chart.js"></script>
 </body>
 </html>

--- a/js/chart.js
+++ b/js/chart.js
@@ -1,0 +1,48 @@
+let liveChart;
+let stepCounter = 0;
+let sumLive = 0;
+function initializeChart() {
+    const ctx = document.getElementById('liveChart').getContext('2d');
+    liveChart = new Chart(ctx, {
+        type: 'line',
+        data: {
+            datasets: [{
+                label: 'Live Cells (avg / 100 steps)',
+                data: [],
+                borderColor: '#4CAF50',
+                backgroundColor: 'rgba(76,175,80,0.2)',
+                tension: 0.1,
+                fill: true,
+            }]
+        },
+        options: {
+            animation: false,
+            scales: {
+                x: { title: { display: true, text: 'Steps' } },
+                y: { title: { display: true, text: 'Live Cells' } }
+            },
+            plugins: { legend: { display: false } }
+        }
+    });
+}
+function addLiveCells(step, count) {
+    if (!liveChart) return;
+    sumLive += count;
+    stepCounter++;
+    if (stepCounter >= 100) {
+        const avg = sumLive / stepCounter;
+        liveChart.data.datasets[0].data.push({ x: step, y: avg });
+        liveChart.update('none');
+        stepCounter = 0;
+        sumLive = 0;
+    }
+}
+function resetChart() {
+    if (liveChart) {
+        liveChart.data.datasets[0].data = [];
+        liveChart.update('none');
+    }
+    stepCounter = 0;
+    sumLive = 0;
+}
+window.ChartModule = { initializeChart, addLiveCells, resetChart };

--- a/js/game.js
+++ b/js/game.js
@@ -120,6 +120,9 @@ function setupWorker() {
             activeCells = new Set(newActive);
             gameState.generation++;
             gameState.liveCells = liveCellCount;
+            if (window.ChartModule) {
+                ChartModule.addLiveCells(gameState.generation, liveCellCount);
+            }
 
             if (gameState.frameCount % gameState.domUpdateInterval === 0) {
                 document.getElementById('generationCount').textContent = gameState.generation;
@@ -300,6 +303,9 @@ function pauseSimulation() {
 function resetSimulation() {
     gameState.generation = 0;
     activeCells.clear();
+    if (window.ChartModule) {
+        ChartModule.resetChart();
+    }
     
     // Calculate grid dimensions
     columnCount = GAME_CONFIG.SIMULATION_WIDTH_CELLS;

--- a/js/ui.js
+++ b/js/ui.js
@@ -217,4 +217,7 @@ window.UIModule = {
 document.addEventListener('DOMContentLoaded', function() {
     console.log("DOM loaded, initializing UI");
     initializeUI();
-}); 
+    if (window.ChartModule) {
+        ChartModule.initializeChart();
+    }
+});


### PR DESCRIPTION
## Summary
- load Chart.js
- create chart container under stats
- style new chart
- implement `chart.js` for live cell tracking averaged every 100 steps
- initialize and update chart from game and UI modules

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6872b238453c83239167d1d6ced215ae